### PR TITLE
Enable Offline Docker Builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,17 @@ Package.resolved
 *.xcodeproj
 build
 docs
+# We exclude deployment scripts from the image builds to prevent
+# them from triggering an image build if we were to `COPY . .`
 scripts
 !scripts/run.sh
 !scripts/init-prereqs.sh
-Sources/Run/Private\ Swiftarr\ Config
-Sources/App/seeds
+# Making these end with a * silences a warning about missing resources
+# during the build
+Sources/Run/Private\ Swiftarr\ Config/*
+Sources/App/seeds/*
+# These areas of the .build directory are needed to prevent fetching
+# deps from the internet during the build.
+!.build/workspace-state.json
+!.build/checkouts
+# vim: ft=conf

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 xcuserdata/
 DerivedData/
 .swiftpm
+.cache
 
 # Python ignores
 __pycache__/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -89,25 +89,27 @@ This assumes you already have Docker or an equivalent OCI-compatible runtime
 available to you. And `docker-compose` (or equivalent).
 
 ### Prerequisites
-You need to decide on your runtime configuration:
-
-| Configuration | Description                                                         |
-|---------------|---------------------------------------------------------------------|
-| Development   | Service dependencies and secondary instances of each for testing.   |
-| Instance      | Service dependencies only.                                          |
-| Linux-Testing | Service dependencies and web server image that will run test suite. |
-| Stack         | Service dependencies and production-ready web server image.         |
-
-Each configuration has a corresponding shell script located in `/scripts` that is a 
-wrapper around `docker-compose` which will aid in getting up and running. All scripts
-should be run from the root of the repo (not from within the scripts directory).
-
-If you are considering doing a Stack deployment you need to decide what environment you
-wish to run. Generally this is `development` or `production`. There isn't a ton of
-difference between the two other than initial database seeding and logging. Regardless,
-you'll need to create config files in `/Sources/Run/Private Swiftarr Config` based on
-the `Docker-Template.env`. See [Installation Notes](https://github.com/challfry/swiftarr/wiki/Installation-Notes#more-info-on-environment-files)
-for more details on what this does.
+1. You need to decide on your runtime configuration:
+   
+   | Configuration | Description                                                         |
+   |---------------|---------------------------------------------------------------------|
+   | Development   | Service dependencies and secondary instances of each for testing.   |
+   | Instance      | Service dependencies only.                                          |
+   | Linux-Testing | Service dependencies and web server image that will run test suite. |
+   | Stack         | Service dependencies and production-ready web server image.         |
+   
+   Each configuration has a corresponding shell script located in `/scripts` that is a 
+   wrapper around `docker-compose` which will aid in getting up and running. All scripts
+   should be run from the root of the repo (not from within the scripts directory).
+   
+   If you are considering doing a Stack deployment you need to decide what environment you
+   wish to run. Generally this is `development` or `production`. There isn't a ton of
+   difference between the two other than initial database seeding and logging. Regardless,
+   you'll need to create config files in `/Sources/Run/Private Swiftarr Config` based on
+   the `Docker-Template.env`. See [Installation Notes](https://github.com/challfry/swiftarr/wiki/Installation-Notes#more-info-on-environment-files)
+   for more details on what this does.
+   
+2. Docker-Compose < 1.26.0 has a bug that causes `env_file` processing to not escape values correctly. If you see strange behavior like timeouts or bad database configuration check your version. 1.25.6 is broken and 1.28.6 works.
 
 ### Build
 This only applies to the Linux-Testing or Stack configurations.
@@ -141,4 +143,68 @@ This only applies to the Linux-Testing or Stack configurations.
    there was no DB for it at the time.
    ```
    scripts/stack.sh -e development restart web
+   ```
+
+### Offline Incremental Builds
+
+You will have had to go through an online build at least once in order for this to work.
+
+Docker will cache:
+* The bage images (`swift`, `ubuntu`, `postgres`, etc).
+* The layers in which we install packages from Apt repos.
+
+But this leaves local Swift package caching. There are a couple files that get seeded 
+into `./.build` when you do a local build (`swift build` or `vapor build` from a dev machine)
+that we can put in place to ensure an offline Docker-based build will also work. Specifically
+they are:
+* `./build/workspace-state.json`
+* `./build/checkouts`
+
+The `Dockerfile.stack` will automatically attempt to copy them into the image build
+context if they exist. As long as they don't change that image layer will cache and
+and there will be a performance benefit in doing incremental Docker builds. Otherwise
+it'll just have to copy them into a new builder image (not the end of the world).
+
+To seed your `./build` directory you can do one of two things:
+1. Perform a local build.
+2. Extract the `/app/.build` contents from a previous Docker build.
+
+To achieve the second option above:
+1. Do an online Docker build.
+   ```
+   scripts/stack.sh -e production build
+   ```
+2. Look in the log for the image ID of the builder that it used. In this example it is `74f20d50b6a6`.
+   ```
+	 [950/951] Compiling Redis Application+Redis.swift
+   remark: Incremental compilation has been disabled: it is not compatible with whole module optimization[952/953] Compiling App AdminController.swift
+   remark: Incremental compilation has been disabled: it is not compatible with whole module optimization[954/955] Compiling Run main.swift
+   [956/956] Linking Run
+   [956/956] Build complete!
+   Removing intermediate container f9ead447694a
+    ---> 74f20d50b6a6 ### HEY THIS IS THE IMAGE ID YOU SEEK ###
+   Step 13/29 : FROM ubuntu:18.04 as base
+    ---> 886eca19e611
+   ```
+3. Create a temporary container based on that image to copy the files from. It helps to give it a human name but that is optional.
+	 ```
+   docker run --name buildertemp 74f20d50b6a6
+   ```
+   This will detatch and exist in the background. We will delete it later but if you get distracted you're on your own for cleanup.
+4. Extract the package and workspace state. Note the trailing slash on the destination.
+   ```
+   mkdir ./.build
+   docker cp buildertemp:/app/.build/workspace-state.json ./.build/
+   docker cp buildertemp:/app/.build/checkouts /.build/
+   ```
+5. Verify that you now have a `./.build` that looks like this:
+   ```
+   ls -l .build
+   total 16K
+   drwxr-xr-x. 29 grant grant 4.0K Jan 27 14:13 checkouts
+   -rw-r--r--.  1 grant grant 8.9K Jan 27 14:13 workspace-state.json
+   ```
+6. Stop and remove the temporary container since we don't need it anymore.
+   ```
+   docker rm buildertemp
    ```

--- a/scripts/Dockerfile.stack
+++ b/scripts/Dockerfile.stack
@@ -1,40 +1,52 @@
 # Builder image
+# 
+# This sets up the environment used to build swiftarr.
 FROM swift:5.5.2-bionic as builder
 
 ARG env
 
 RUN apt-get -qq update && apt-get install -y \
     libssl-dev zlib1g-dev libgd-dev
+RUN mkdir -p /build/lib && cp -R /usr/lib/swift/linux/*.so* /build/lib
 
 WORKDIR /app
+
 # Not copying "." means that changes to the runtime scripts do not trigger
 # a complete application rebuild, which saves a lot of time.
+#
+# We copy some of the .build directory to prevent having to fetch state
+# from the internet during a rebuild. Note that this requires
+# the .build directory to exist which means you've seeded it from somewhere
+# or done a local build.
+#
+# The README.md here is a hack to conditionally copy based on whether you have
+# done a local build or not. This is pretty ghetto but I think it's the only
+# way to allow for an offline build while maintaining compatibility for
+# fresh users. The trailing / is important here so don't screw that up.
+# https://redgreenrepeat.com/2018/04/13/how-to-conditionally-copy-file-in-dockerfile/
+COPY ./README.md ./.build/checkouts* /app/.build/checkouts/
+COPY ./README.md ./.build/workspace-state.json* /app/.build/
+# We copy the app sources after the .build so that the image build can use
+# the cached image layer.
 COPY ./Sources /app/Sources
 COPY ./Package.* /app
 COPY ./Tests /app/Tests
 
-RUN mkdir -p /build/lib && cp -R /usr/lib/swift/linux/*.so* /build/lib
+# This runs the actual build.
 RUN swift build -c release && mv `swift build -c release --show-bin-path` /build/bin
 
-# Production image
-FROM ubuntu:18.04
+# Base image
+#
+# This has its own build stage to allow the depedencies from the internet
+# to be installed in a cached image. Otherwise it'd be running the steps
+# every time which we don't want.
+FROM ubuntu:18.04 as base
 
-ARG env
-ENV ENVIRONMENT=$env
-ENV AUTO_MIGRATE=true
-
-# Image setup
+# Prereqs
 COPY scripts/init-prereqs.sh /
 COPY scripts/run.sh /
 RUN mkdir -p /app/images
 RUN /init-prereqs.sh
-
-# App installation
-WORKDIR /app
-COPY --from=builder /build/bin/Run /app
-COPY --from=builder /build/lib/* /usr/lib/
-COPY --from=builder /build/bin/swiftarr_App.resources /app/swiftarr_App.resources
-# @TODO tests???
 
 # User
 RUN useradd -U -d /app -c "Swiftarr App User" -s /bin/bash swiftarr
@@ -43,3 +55,19 @@ USER swiftarr:swiftarr
 
 # Run
 CMD ["/run.sh"]
+
+# Actual Swiftarr Image
+#
+# This sources from the base image we built above.
+FROM base
+
+ARG env
+ENV ENVIRONMENT=$env
+ENV AUTO_MIGRATE=true
+
+# App installation
+WORKDIR /app
+COPY --from=builder /build/bin/Run /app
+COPY --from=builder /build/lib/* /usr/lib/
+COPY --from=builder /build/bin/swiftarr_App.resources /app/swiftarr_App.resources
+# @TODO tests???


### PR DESCRIPTION
Some modifications were required to perform Docker builds in an offline environment. It's a bit shady and I'm not proud but the process is repeatable and documented (via INSTALL.md).

This also removes the seeds from the image.