### PR TITLE
Enable serving static arbitrary content

### DIFF
--- a/Sources/App/Site/SiteFileController.swift
+++ b/Sources/App/Site/SiteFileController.swift
@@ -4,37 +4,46 @@ import Fluent
 /// Serves static files used bye the Web UI front end. Since these files are UI-level and not API-level entities, we serve
 /// these files directly from here--there's no need to forward calls through the API. This means if you're an API client, you
 /// shouldn't be using the files served from these endpoints.
+///
+/// Files dynamically created currently require a restart to pick up.
 struct SiteFileController: SiteControllerUtils {
 
-	func registerRoutes(_ app: Application) throws {
-	
-		// Routes that the user does not need to be logged in to access.
-		app.get("css", "**", use: streamCSSFile)
-		app.get("img", "**", use: streamImgFile)
-		app.get("js", "**", use: streamJSFile)
+    func registerRoutes(_ app: Application) throws {
 
+        // Routes that the user does not need to be logged in to access.
+        app.get("css", "**", use: streamCSSFile)
+        app.get("img", "**", use: streamImgFile)
+        app.get("js", "**", use: streamJSFile)
+		// This replaces FileMiddleware from Sources/App/configure.swift.
+		app.get("public", "**", use: streamPublicFile)
+
+    }
+
+    // `GET /css/:catchall`
+    //
+    // :catchall is any path after "/css/", not just a single filename.
+    func streamCSSFile(_ req: Request) throws -> EventLoopFuture<Response> {
+        return try streamFile(req, basePath: "css")
+    }
+
+    // `GET /img/:catchall`
+    func streamImgFile(_ req: Request) throws -> EventLoopFuture<Response> {
+        return try streamFile(req, basePath: "img")
+    }
+
+    // `GET /js/:catchall`
+    func streamJSFile(_ req: Request) throws -> EventLoopFuture<Response> {
+        return try streamFile(req, basePath: "js")
+    }
+
+	// `GET /public/:catchall`
+	func streamPublicFile(_ req: Request) throws -> EventLoopFuture<Response> {
+		return try streamFile(req, basePath: "public")
 	}
 
-	// `GET /css/:catchall`
-	//
-	// :catchall is any path after "/css/", not just a single filename.
-	func streamCSSFile(_ req: Request) throws -> EventLoopFuture<Response> {
-		return try streamFile(req, basePath: "css")
-	}
-
-	// `GET /img/:catchall`
-	func streamImgFile(_ req: Request) throws -> EventLoopFuture<Response> {
-		return try streamFile(req, basePath: "img")
-	}
-
-	// `GET /js/:catchall`
-	func streamJSFile(_ req: Request) throws -> EventLoopFuture<Response> {
-		return try streamFile(req, basePath: "js")
-	}
-	
-	// Wraps fileio.streamFile. Sanity-checks the path, builds a file system path to the resource,
-	// and streams the resource file. Adds a cache-control header as all these files are long-lived and shouldn't change.
-	func streamFile(_ req: Request, basePath: String) throws -> EventLoopFuture<Response> {
+    // Wraps fileio.streamFile. Sanity-checks the path, builds a file system path to the resource,
+    // and streams the resource file. Adds a cache-control header as all these files are long-lived and shouldn't change.
+    func streamFile(_ req: Request, basePath: String) throws -> EventLoopFuture<Response> {
         // make a copy of the percent-decoded path
         guard var path = req.parameters.getCatchall().joined(separator: "/").removingPercentEncoding else {
             return req.eventLoop.makeFailedFuture(Abort(.badRequest))
@@ -51,21 +60,21 @@ struct SiteFileController: SiteControllerUtils {
         }
 
         // create absolute file path
-		let filePath = Settings.shared.staticFilesRootPath
-				.appendingPathComponent("Resources/Assets/\(basePath)")
-				.appendingPathComponent(path)
+        let filePath = Settings.shared.staticFilesRootPath
+                .appendingPathComponent("Resources/Assets/\(basePath)")
+                .appendingPathComponent(path)
 
         // check if file exists and is not a directory
         var isDir: ObjCBool = false
         guard FileManager.default.fileExists(atPath: filePath.path, isDirectory: &isDir), !isDir.boolValue else {
-			throw Abort(.notFound)
+            throw Abort(.notFound)
         }
 
         // stream the file, then add a "Cache-Control" header with a 24 hour freshness time.
         let response = req.fileio.streamFile(at: filePath.path)
-		if response.status == .ok || response.status == .notModified {
-			response.headers.cacheControl = .init(isPublic: true, maxAge: 3600 * 24)
-		}        
+        if response.status == .ok || response.status == .notModified {
+            response.headers.cacheControl = .init(isPublic: true, maxAge: 3600 * 24)
+        }
         return req.eventLoop.makeSucceededFuture(response)
-	}
+    }
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -474,12 +474,15 @@ func verifyConfiguration(_ app: Application) throws {
 		app.logger.critical("Resource files not found during launchtime sanity check. This usually means the Resources directory isn't getting copied into the App directory in /DerivedData.")
 	}
 
-	// Enable sharing anything out of the Public directory (at the app root). The directory does not
-	// have to exist when the app starts so it can be mounted in at any time. By default this translates
-	// to "Public" (adjacent to Sources in the code repo) or "/app/Public" in Docker.
-	let fileMiddleware = FileMiddleware(publicDirectory: app.directory.publicDirectory)
-	app.middleware.use(fileMiddleware)
-	app.logger.notice("Serving static content from \(app.directory.publicDirectory).")
+  // FileMiddleware checks eTags and will respond with NotModified, but doesn't set cache-control,
+  // which we probably show for static files. That was the main reason for creating SiteFileController
+  // and using it instead of FileMiddleware.
+  //
+  // SiteFileController just serves static files: images, css, and javascript files. Improvements over
+  // fileMiddleware are that fileMiddleware ran globally on every request, and we couldn’t set
+  // cache-control headers with fileMiddleware.
+  //
+  // tldr: Don't use the FileMiddleware.
 }
 
 // Found this in a Github search. Seems to be good enough for our needs unless someone has better ideas.

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -473,6 +473,13 @@ func verifyConfiguration(_ app: Application) throws {
 	if !cssFileFound {
 		app.logger.critical("Resource files not found during launchtime sanity check. This usually means the Resources directory isn't getting copied into the App directory in /DerivedData.")
 	}
+
+	// Enable sharing anything out of the Public directory (at the app root). The directory does not
+	// have to exist when the app starts so it can be mounted in at any time. By default this translates
+	// to "Public" (adjacent to Sources in the code repo) or "/app/Public" in Docker.
+	let fileMiddleware = FileMiddleware(publicDirectory: app.directory.publicDirectory)
+	app.middleware.use(fileMiddleware)
+	app.logger.notice("Serving static content from \(app.directory.publicDirectory).")
 }
 
 // Found this in a Github search. Seems to be good enough for our needs unless someone has better ideas.


### PR DESCRIPTION
This sets us up to easily serve random static content (such as the KrakenPost list). Any content can be dynamically added to the server in the appropriate directory and immediately be available.