### PR TITLE
Fix content header disposition issue with chrome

### DIFF
--- a/Sources/App/Site/SiteEventsController.swift
+++ b/Sources/App/Site/SiteEventsController.swift
@@ -125,7 +125,8 @@ struct SiteEventsController: SiteControllerUtils {
 		return apiQuery(req, endpoint: "/events/\(eventID)").throwingFlatMap { response in
  			let event = try response.content.decode(EventData.self)
 			let icsString = buildEventICS(event: event)
-			let headers = HTTPHeaders([("Content-Disposition", "attachment; filename=\(event.title).ics")])
+			let cleanEventTitle = event.title.replacingOccurrences(of: "\"", with: "")
+			let headers = HTTPHeaders([("Content-Disposition", "attachment; filename=\"\(cleanEventTitle).ics\"")])
 			return icsString.encodeResponse(status: .ok, headers: headers, for: req)
 		}
     }


### PR DESCRIPTION
When downloading an ICS from the schedule that had spaces or quotes in the title, Chrome gave an error: `ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION`. Per https://stackoverflow.com/questions/39404949/err-response-headers-multiple-content-disposition it sounds like this is a Chrome-specific thing and can be solved by quoting the file name. This exploded with quotes in the event title so we now calculate a sanitized event title to use for file downloads. 

Tested in Chrome and Firefox.