### PR TITLE
Add "Display Time" setting to control perception of time

### DIFF
--- a/Sources/App/Controllers/AdminController.swift
+++ b/Sources/App/Controllers/AdminController.swift
@@ -143,6 +143,9 @@ struct AdminController: APIRouteCollection {
 			throw Abort(.forbidden, reason: "Admin only")
 		}
  		let data = try ValidatingJSONDecoder().decode(SettingsUpdateData.self, fromBodyOf: req)
+		guard TimeZone(abbreviation: data.displayTimeZone ?? "") != nil else {
+			throw Abort(.badRequest, reason: "Bad time zone given.")
+		}
  		if let value = data.maxAlternateAccounts {
  			Settings.shared.maxAlternateAccounts = value
  		}
@@ -170,6 +173,9 @@ struct AdminController: APIRouteCollection {
  		if let value = data.allowAnimatedImages {
  			Settings.shared.allowAnimatedImages = value
  		}
+		if let value = data.displayTimeZone {
+			Settings.shared.displayTimeZone = value
+		}
  		var localDisables = Settings.shared.disabledFeatures.value
  		for pair in data.enableFeatures {
  			if let app = SwiftarrClientApp(rawValue: pair.app), let feature = SwiftarrFeature(rawValue: pair.feature) {

--- a/Sources/App/Controllers/ClientController.swift
+++ b/Sources/App/Controllers/ClientController.swift
@@ -18,6 +18,9 @@ struct ClientController: APIRouteCollection {
 		// convenience route group for all /api/v3/client endpoints
 		let clientRoutes = app.grouped("api", "v3", "client")
 
+        // open access endpoints
+        clientRoutes.get("time", use: clientTimeHandler)
+
 		// endpoints available only when logged in
 		let tokenAuthGroup = addTokenAuthGroup(to: clientRoutes)
 		tokenAuthGroup.get("user", "updates", "since", ":date", use: userUpdatesHandler)
@@ -139,6 +142,17 @@ struct ClientController: APIRouteCollection {
 		}
 		return promise.futureResult
 	}
+
+    /// `GET /api/v3/client/time`
+    ///
+    /// Return the current time on the server in ISO8601 format. Useful for figuring out when you are.
+    func clientTimeHandler(_ req: Request) -> EventLoopFuture<String> {
+        // https://stackoverflow.com/questions/58307194/swift-utc-timezone-is-not-utc
+        let formatter = DateFormatter()
+        formatter.timeZone = TimeZone.current
+        formatter.setLocalizedDateFormatFromTemplate("MMMM dd hh:mm a zzzz")
+        return req.eventLoop.makeSucceededFuture(formatter.string(from: Date()))
+    }
 
     // MARK: - Helper Functions
 }

--- a/Sources/App/Controllers/ClientController.swift
+++ b/Sources/App/Controllers/ClientController.swift
@@ -147,8 +147,8 @@ struct ClientController: APIRouteCollection {
     ///
     /// Return some information on the current time configuration of the server. This also
     /// should provide hints to clients on how to render time correctly.
-    func clientTimeHandler(_ req: Request) -> EventLoopFuture<ClientTimeStruct> {
-        return req.eventLoop.makeSucceededFuture(ClientTimeData())
+    func clientTimeHandler(_ req: Request) -> EventLoopFuture<ServerTimeData> {
+        return req.eventLoop.makeSucceededFuture(ServerTimeData())
     }
 
     // MARK: - Helper Functions

--- a/Sources/App/Controllers/ClientController.swift
+++ b/Sources/App/Controllers/ClientController.swift
@@ -145,13 +145,10 @@ struct ClientController: APIRouteCollection {
 
     /// `GET /api/v3/client/time`
     ///
-    /// Return the current time on the server in ISO8601 format. Useful for figuring out when you are.
-    func clientTimeHandler(_ req: Request) -> EventLoopFuture<String> {
-        // https://stackoverflow.com/questions/58307194/swift-utc-timezone-is-not-utc
-        let formatter = DateFormatter()
-        formatter.timeZone = TimeZone.current
-        formatter.setLocalizedDateFormatFromTemplate("MMMM dd hh:mm a zzzz")
-        return req.eventLoop.makeSucceededFuture(formatter.string(from: Date()))
+    /// Return some information on the current time configuration of the server. This also
+    /// should provide hints to clients on how to render time correctly.
+    func clientTimeHandler(_ req: Request) -> EventLoopFuture<ClientTimeStruct> {
+        return req.eventLoop.makeSucceededFuture(ClientTimeData())
     }
 
     // MARK: - Helper Functions

--- a/Sources/App/Controllers/Structs/AdminControllerStructs.swift
+++ b/Sources/App/Controllers/Structs/AdminControllerStructs.swift
@@ -110,6 +110,7 @@ public struct SettingsAdminData: Content {
 	var allowAnimatedImages: Bool
 	/// Currently disabled app:feature pairs.
 	var disabledFeatures: [SettingsAppFeaturePair]
+	var displayTimeZone: String
 }
 
 extension SettingsAdminData {
@@ -123,6 +124,7 @@ extension SettingsAdminData {
 		self.postAutoQuarantineThreshold = settings.postAutoQuarantineThreshold
 		self.userAutoQuarantineThreshold = settings.userAutoQuarantineThreshold
 		self.allowAnimatedImages = settings.allowAnimatedImages
+		self.displayTimeZone = settings.displayTimeZone
 		disabledFeatures = []
 		for (app, features) in settings.disabledFeatures.value {
 			for feature in features {
@@ -153,4 +155,5 @@ public struct SettingsUpdateData: Content {
 	var enableFeatures: [SettingsAppFeaturePair]
 	/// App:feature pairs to disable. Only list deltas here; no need to re-list currently disabled app:feature pairs..
 	var disableFeatures: [SettingsAppFeaturePair]
+	var displayTimeZone: String?
 }

--- a/Sources/App/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/App/Controllers/Structs/ControllerStructs.swift
@@ -1737,7 +1737,8 @@ fileprivate func usernameValidations(username: String) -> [String] {
 }
 
 /// Time information struct. This gives a couple values that a client can use to determine what time it really is.
-public struct ClientTimeData: Content {
+/// Maybe someday this will also include a list of the different time changes.
+public struct ServerTimeData: Content {
 	/// Current time and date according to the server.
 	var serverTime: Date
 	/// Current time zone of the server.
@@ -1747,12 +1748,24 @@ public struct ClientTimeData: Content {
 	/// Time zone of the Display Time.
 	var displayTimeZone: TimeZone
 
-	func to_human_s(date: Date = Date(), timeZone: TimeZone = TimeZone.autoupdatingCurrent) -> String {
+	/// Internal function to take a given date and timezone and return the time in a human-readable
+	/// pretty format that we just happened to decide on.
+	private func to_human_s(date: Date = Date(), timeZone: TimeZone) -> String {
 		let formatter = DateFormatter()
         formatter.timeZone = timeZone
 		// This formatting was arbitrarily taken from Twitarr v2.
         formatter.setLocalizedDateFormatFromTemplate("MMMM dd hh:mm a zzzz")
 		return formatter.string(from: date)
+	}
+
+	/// Quick accessor to pretty-formatted server time.
+	public func serverTimeHuman() -> String {
+		return to_human_s(date: self.serverTime, timeZone: self.serverTimeZone)
+	}
+
+	/// Quick accessor to pretty-foramtted display time.
+	public func displayTimeHuman() -> String {
+		return to_human_s(date: self.displayTime, timeZone: self.displayTimeZone)
 	}
 
 	init(serverTime: Date = Date(), displayTime: Date = Date(), displayTimeZoneAbbreviation: String = Settings.shared.displayTimeZone) {

--- a/Sources/App/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/App/Controllers/Structs/ControllerStructs.swift
@@ -1736,3 +1736,29 @@ fileprivate func usernameValidations(username: String) -> [String] {
 	return errorStrings
 }
 
+/// Time information struct. This gives a couple values that a client can use to determine what time it really is.
+public struct ClientTimeData: Content {
+	/// Current time and date according to the server.
+	var serverTime: Date
+	/// Current time zone of the server.
+	var serverTimeZone: TimeZone
+	/// Current time and date after factoring in the Display Time.
+	var displayTime: Date
+	/// Time zone of the Display Time.
+	var displayTimeZone: TimeZone
+
+	func to_human_s(date: Date = Date(), timeZone: TimeZone = TimeZone.autoupdatingCurrent) -> String {
+		let formatter = DateFormatter()
+        formatter.timeZone = timeZone
+		// This formatting was arbitrarily taken from Twitarr v2.
+        formatter.setLocalizedDateFormatFromTemplate("MMMM dd hh:mm a zzzz")
+		return formatter.string(from: date)
+	}
+
+	init(serverTime: Date = Date(), displayTime: Date = Date(), displayTimeZoneAbbreviation: String = Settings.shared.displayTimeZone) {
+		self.serverTime = serverTime
+		self.serverTimeZone = TimeZone.autoupdatingCurrent
+		self.displayTime = displayTime
+		self.displayTimeZone = TimeZone(abbreviation: displayTimeZoneAbbreviation) ?? TimeZone.autoupdatingCurrent
+	}
+}

--- a/Sources/App/Helpers/Settings.swift
+++ b/Sources/App/Helpers/Settings.swift
@@ -105,6 +105,9 @@ final class Settings : Encodable {
 
 	/// The length in days of the cruise, includes partial days. A cruise that embarks on Saturday and returns the next Saturday should have a value of 8.
 	@SettingsValue var cruiseLengthInDays: Int = 8
+
+	/// The time zone to display time in.
+	@StoredSettingsValue("displayTimeZone", defaultValue: "EST") var displayTimeZone: String
 	
 // MARK: Images
 	/// The  set of image file types that we can parse with the GD library. I believe GD hard-codes these values on install based on what ./configure finds.

--- a/Sources/App/Resources/Assets/js/swiftarr.js
+++ b/Sources/App/Resources/Assets/js/swiftarr.js
@@ -523,3 +523,20 @@ document.getElementById('imageCarouselModal')?.addEventListener('show.bs.modal',
 	deleteBtn.setAttribute('data-delete-postid', postElem.dataset.postid);
 })
 
+// It would be really nice if we could easily break this out into a time-only script. But since
+// we don't have a pattern for that yet I'm not looking to re-invent the wheel just yet.
+window.addEventListener('DOMContentLoaded', function() {
+	if (document.getElementById('browserTimeDisplay')) {
+		browserTime = new Date();
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatToParts
+		var formatter = new Intl.DateTimeFormat('en-us', {
+			month: 'long',
+			day: '2-digit',
+			hour: 'numeric', // Swift is supposed to give 2-digit but it isn't working. At least this matches.
+			minute: '2-digit',
+			hour12: true,
+			timeZoneName: 'long'
+		  });
+		document.getElementById('browserTimeDisplay').innerHTML = formatter.format(browserTime)
+	}
+})

--- a/Sources/App/Resources/Views/admin/serversettings.html
+++ b/Sources/App/Resources/Views/admin/serversettings.html
@@ -100,6 +100,12 @@
 							#endfor
 						</select>
 					</div>
+					<div class="row my-1">
+						<div class="col">
+							<label for="displayTimeZone">Time Zone for displaying time</label>
+							<input type="text" id="displayTimeZone" name="displayTimeZone" value="#(settings.displayTimeZone)">
+						</div>
+					</div>
 				</div>
 				<div class="alert alert-danger mt-3 d-none" role="alert">
 				</div>				

--- a/Sources/App/Resources/Views/time.html
+++ b/Sources/App/Resources/Views/time.html
@@ -6,17 +6,19 @@
             </div>
             <div class="row">
                 <p>
-                    More information about time changes will be added SoonTM.
+                    JoCo Cruise will be making at least one time zone change this year. St Croix is in Atlantic Standard 
+                    Time while the rest of our voyage will be in Eastern Standard Time. Be careful when scheduling events 
+                    that you take note of the expected time zone. The server that Twitarr runs on will be in UTC (Coordinated 
+                    Universal Time, Greenwich Mean Time, Zero/Zulu time) for the duration of the cruise.
                 </p>
             </div>
             <div class="row">
                 <p><b>Server time: </b><span id="serverTimeDisplay">#(serverTime)</span></p>
                 <p><b>Display time: </b><span id="displayTimeDisplay">#(displayTime)</span></p>
                 <p><b>Device time: </b><span id="browserTimeDisplay">Unknown</span></p>
-                <p><b>Configured display time zone (on server): </b><span>#(trunk.displayTimeZone.identifier)</span></p>
             </div>
             <div class="row">
-                <p>If the two times above are different, you should change the time zone on your device until they match. This should be in your settings somewhere, but if you can't find it, ask a tech nerd. The good news is, there's probably one nearby. :)</p>
+                <p>If the <b>Display time</b> and <b>Device time</b> above are different, you should change the time zone on your device until they match. This should be in your settings somewhere. If you can't find it, ask a tech nerd. There's probably one nearby.</p>
             </div>
 		</div>
     #endexport

--- a/Sources/App/Resources/Views/time.html
+++ b/Sources/App/Resources/Views/time.html
@@ -10,8 +10,9 @@
                 </p>
             </div>
             <div class="row">
-                <p><b>Time on the server: </b><span id="serverTimeDisplay">#(serverTime)</span></p>
-                <p><b>Time on your device: </b><span id="browserTimeDisplay">Unknown</span></p>
+                <p><b>Server time: </b><span id="serverTimeDisplay">#(serverTime)</span></p>
+                <p><b>Display time: </b><span id="displayTimeDisplay">#(displayTime)</span></p>
+                <p><b>Device time: </b><span id="browserTimeDisplay">Unknown</span></p>
                 <p><b>Configured display time zone (on server): </b><span>#(trunk.displayTimeZone.identifier)</span></p>
             </div>
             <div class="row">

--- a/Sources/App/Resources/Views/time.html
+++ b/Sources/App/Resources/Views/time.html
@@ -6,13 +6,12 @@
             </div>
             <div class="row">
                 <p>
-                    JoCo Cruise will not be making any time zone changes this year, but Daylight Saving Time will begin on Day 2 (Sunday). The server that Twit-arr runs on will be in Eastern Time for the duration of the cruise. If your device is set to Eastern Time, it should automatically update to Daylight Saving Time when it begins. HEY FIX ME.
-                    We will be in EST for the first day of the cruise, and EDT for all other days of the cruise.
+                    More information about time changes will be added SoonTM.
                 </p>
             </div>
             <div class="row">
-                <p><b>Time on the server: </b>Party Time</p>
-                <p><b>Time on your device: </b>Other Time</p>
+                <p><b>Time on the server: </b><span id="serverTimeDisplay">#(serverTime)</span></p>
+                <p><b>Time on your device: </b><span id="browserTimeDisplay">Unknown</span></p>
             </div>
             <div class="row">
                 <p>If the two times above are different, you should change the time zone on your device until they match. This should be in your settings somewhere, but if you can't find it, ask a tech nerd. The good news is, there's probably one nearby. :)</p>

--- a/Sources/App/Resources/Views/time.html
+++ b/Sources/App/Resources/Views/time.html
@@ -1,0 +1,22 @@
+#extend("trunk"):
+    #export("body"):
+    	<div class="container-fluid">
+            <div class="row my-3">
+                <h4>Time Zone Check</h4>
+            </div>
+            <div class="row">
+                <p>
+                    JoCo Cruise will not be making any time zone changes this year, but Daylight Saving Time will begin on Day 2 (Sunday). The server that Twit-arr runs on will be in Eastern Time for the duration of the cruise. If your device is set to Eastern Time, it should automatically update to Daylight Saving Time when it begins. HEY FIX ME.
+                    We will be in EST for the first day of the cruise, and EDT for all other days of the cruise.
+                </p>
+            </div>
+            <div class="row">
+                <p><b>Time on the server: </b>Party Time</p>
+                <p><b>Time on your device: </b>Other Time</p>
+            </div>
+            <div class="row">
+                <p>If the two times above are different, you should change the time zone on your device until they match. This should be in your settings somewhere, but if you can't find it, ask a tech nerd. The good news is, there's probably one nearby. :)</p>
+            </div>
+		</div>
+    #endexport
+#endextend

--- a/Sources/App/Resources/Views/time.html
+++ b/Sources/App/Resources/Views/time.html
@@ -12,6 +12,7 @@
             <div class="row">
                 <p><b>Time on the server: </b><span id="serverTimeDisplay">#(serverTime)</span></p>
                 <p><b>Time on your device: </b><span id="browserTimeDisplay">Unknown</span></p>
+                <p><b>Configured display time zone (on server): </b><span>#(trunk.displayTimeZone.identifier)</span></p>
             </div>
             <div class="row">
                 <p>If the two times above are different, you should change the time zone on your device until they match. This should be in your settings somewhere, but if you can't find it, ask a tech nerd. The good news is, there's probably one nearby. :)</p>

--- a/Sources/App/Resources/Views/trunk.html
+++ b/Sources/App/Resources/Views/trunk.html
@@ -84,6 +84,9 @@
 					<li class="nav-item">
 						<a class="nav-link #if(trunk.tab == "karaoke"): active#endif" href="/karaoke">Karaoke</a>
 					</li>
+					<li class="nav-item">
+						<a class="nav-link #if(trunk.tab == "time"): active#endif" href="/time">Time Zone Check</a>
+					</li>
 					#if(trunk.userIsMod):
 						<hr class="main-menu-divider">
 						<li class="nav-item d-flex align-items-center">

--- a/Sources/App/Site/CustomLeafTags.swift
+++ b/Sources/App/Site/CustomLeafTags.swift
@@ -255,7 +255,8 @@ struct EventTimeTag: LeafTag {
 		dateFormatter.dateStyle = .short
 		dateFormatter.timeStyle = .short
 		dateFormatter.locale = Locale(identifier: "en_US")
-		dateFormatter.timeZone = TimeZone.autoupdatingCurrent
+		let timeZone = TimeZone(abbreviation: Settings.shared.displayTimeZone) ?? TimeZone.autoupdatingCurrent
+		dateFormatter.timeZone = timeZone
 		var timeString = dateFormatter.string(from: Date(timeIntervalSince1970: startTimeDouble))
 		dateFormatter.dateStyle = .none
 		timeString.append(" - \(dateFormatter.string(from: Date(timeIntervalSince1970: endTimeDouble)))")

--- a/Sources/App/Site/SiteAdminController.swift
+++ b/Sources/App/Site/SiteAdminController.swift
@@ -382,6 +382,7 @@ struct SiteAdminController: SiteControllerUtils {
 			var allowAnimatedImages: String?
 			var disableAppName: String
 			var disableFeatureName: String
+			var displayTimeZone: String
 			// In the .leaf file, the name property for the select that sets this is "reenable[]". 
 			// The "[]" in the name is magic, somewhere in multipart-kit. It collects all form-data value with the same name into an array.
 			var reenable: [String]?				
@@ -413,7 +414,8 @@ struct SiteAdminController: SiteControllerUtils {
 				postAutoQuarantineThreshold: postStruct.postAutoQuarantineThreshold, 
 				userAutoQuarantineThreshold: postStruct.userAutoQuarantineThreshold, 
 				allowAnimatedImages: postStruct.allowAnimatedImages == "on",
-				enableFeatures: enablePairs, disableFeatures: disablePairs)
+				enableFeatures: enablePairs, disableFeatures: disablePairs,
+				displayTimeZone: postStruct.displayTimeZone)
 		return apiQuery(req, endpoint: "/admin/serversettings/update", method: .POST, beforeSend: { req throws in
 			try req.content.encode(apiPostContent)
 		}).flatMapThrowing { response in

--- a/Sources/App/Site/SiteController.swift
+++ b/Sources/App/Site/SiteController.swift
@@ -372,8 +372,12 @@ struct SiteController: SiteControllerUtils {
 		// Routes that the user does not need to be logged in to access.
 		let openRoutes = getOpenRoutes(app)
         openRoutes.get(use: rootPageHandler)
+		openRoutes.get("time", use: timePageHandler)
 	}
 	
+	/// GET /
+	///
+	/// Root page. This has a surprising number of queries.
     func rootPageHandler(_ req: Request) throws -> EventLoopFuture<View> {
 		return apiQuery(req, endpoint: "/notification/announcements").throwingFlatMap { response in
  			let announcements = try response.content.decode([AnnouncementData].self)
@@ -415,6 +419,23 @@ struct SiteController: SiteControllerUtils {
 			}
 		}
     }
+
+	/// GET /time
+	///
+	/// Timezone information page.
+	func timePageHandler(_ req: Request) throws -> EventLoopFuture<View> {
+		struct TimePageContext : Encodable {
+			var trunk: TrunkContext
+			var serverDate: Date
+
+			init(_ req: Request) throws {
+				trunk = .init(req, title: "Twitarr", tab: .home)
+				serverDate = Date()
+			}
+		}
+		let ctx = try TimePageContext(req)
+		return req.view.render("time", ctx)
+	}
     
 }
     

--- a/Sources/App/Site/SiteController.swift
+++ b/Sources/App/Site/SiteController.swift
@@ -434,14 +434,21 @@ struct SiteController: SiteControllerUtils {
 			struct TimePageContext : Encodable {
 				var trunk: TrunkContext
 				var serverTime: String
+				var displayTime: String
 
-				init(_ req: Request, serverTime: String) throws {
+				init(_ req: Request, serverTime: String, displayTime: String) throws {
 					trunk = .init(req, title: "Twitarr", tab: .time)
 					self.serverTime = serverTime
+					self.displayTime = displayTime
 				}
 			}
 
-			let ctx = try TimePageContext(req, serverTime: serverTime)
+			let formatter = DateFormatter()
+			formatter.timeZone = TimeZone(abbreviation: Settings.shared.displayTimeZone) ?? TimeZone.autoupdatingCurrent
+        	formatter.setLocalizedDateFormatFromTemplate("MMMM dd hh:mm a zzzz")
+			let displayTime = formatter.string(from: Date())
+
+			let ctx = try TimePageContext(req, serverTime: serverTime, displayTime: displayTime)
 			return req.view.render("time", ctx)
 		}
 

--- a/Sources/App/Site/SiteController.swift
+++ b/Sources/App/Site/SiteController.swift
@@ -22,6 +22,7 @@ struct TrunkContext: Encodable {
 		case karaoke
 		case moderator
 		case admin
+		case time
 		
 		case none
 	}
@@ -424,17 +425,23 @@ struct SiteController: SiteControllerUtils {
 	///
 	/// Timezone information page.
 	func timePageHandler(_ req: Request) throws -> EventLoopFuture<View> {
-		struct TimePageContext : Encodable {
-			var trunk: TrunkContext
-			var serverDate: Date
+		return apiQuery(req, endpoint: "/client/time").throwingFlatMap { serverTimeResponse in
+			let serverTime = try serverTimeResponse.content.decode(String.self)
 
-			init(_ req: Request) throws {
-				trunk = .init(req, title: "Twitarr", tab: .home)
-				serverDate = Date()
+			struct TimePageContext : Encodable {
+				var trunk: TrunkContext
+				var serverTime: String
+
+				init(_ req: Request, serverTime: String) throws {
+					trunk = .init(req, title: "Twitarr", tab: .time)
+					self.serverTime = serverTime
+				}
 			}
+
+			let ctx = try TimePageContext(req, serverTime: serverTime)
+			return req.view.render("time", ctx)
 		}
-		let ctx = try TimePageContext(req)
-		return req.view.render("time", ctx)
+
 	}
     
 }

--- a/Sources/App/Site/SiteController.swift
+++ b/Sources/App/Site/SiteController.swift
@@ -429,7 +429,7 @@ struct SiteController: SiteControllerUtils {
 	/// Timezone information page.
 	func timePageHandler(_ req: Request) throws -> EventLoopFuture<View> {
 		return apiQuery(req, endpoint: "/client/time").throwingFlatMap { serverTimeResponse in
-			let serverTime = try serverTimeResponse.content.decode(String.self)
+			let serverTimeData = try serverTimeResponse.content.decode(ServerTimeData.self)
 
 			struct TimePageContext : Encodable {
 				var trunk: TrunkContext
@@ -443,12 +443,7 @@ struct SiteController: SiteControllerUtils {
 				}
 			}
 
-			let formatter = DateFormatter()
-			formatter.timeZone = TimeZone(abbreviation: Settings.shared.displayTimeZone) ?? TimeZone.autoupdatingCurrent
-        	formatter.setLocalizedDateFormatFromTemplate("MMMM dd hh:mm a zzzz")
-			let displayTime = formatter.string(from: Date())
-
-			let ctx = try TimePageContext(req, serverTime: serverTime, displayTime: displayTime)
+			let ctx = try TimePageContext(req, serverTime: serverTimeData.serverTimeHuman(), displayTime: serverTimeData.displayTimeHuman())
 			return req.view.render("time", ctx)
 		}
 

--- a/Sources/App/Site/SiteController.swift
+++ b/Sources/App/Site/SiteController.swift
@@ -39,6 +39,8 @@ struct TrunkContext: Encodable {
 	var eventStartingSoon: Bool
 	var newTweetAlertwords: Bool
 	var newForumAlertwords: Bool
+
+	var displayTimeZone: TimeZone
 	
 	init(_ req: Request, title: String, tab: Tab, search: String? = nil) {
 		if let user = req.auth.get(UserCacheData.self) {
@@ -76,6 +78,7 @@ struct TrunkContext: Encodable {
 		self.tab = tab
 		self.inTwitarrSubmenu = [.home, .lfg, .games, .karaoke, .moderator, .admin].contains(tab)
 		self.searchPrompt = search
+		self.displayTimeZone = TimeZone(abbreviation: Settings.shared.displayTimeZone) ?? TimeZone(abbreviation: "UTC")!
 		
 		newTweetAlertwords = alertCounts.alertWords.contains { $0.newTwarrtMentionCount > 0 }
 		newForumAlertwords = alertCounts.alertWords.contains { $0.newForumMentionCount > 0 }


### PR DESCRIPTION
This supersedes https://github.com/challfry/swiftarr/pull/25 since that is a dependency. This PR adds the ability to set a "display time zone" that controls how time data is rendered. Events, Fez's, etc are all stored in the database as UTC. There are a couple places long they way they were translated back to EST or were simply not leading to some strange and whacky times.

This works when the server is in EST mode. UTC still has issues with entering events/groups/etc since it expects the date in the server time zone which is difficult to process. This also does not yet account for putting a timezone label on all of those fields as a hint to users of what to do.