### PR TITLE
Pointer cursor for Twit-arr menu

### DIFF
--- a/Sources/App/Resources/Assets/css/swiftarr.css
+++ b/Sources/App/Resources/Assets/css/swiftarr.css
@@ -29,6 +29,10 @@ hr.newline:after {
 	opacity: 100%;
 }
 
+.navbar-brand {
+  cursor: pointer;
+}
+
 .nav-item.nav-link.active {
   font-weight: 700;
 }


### PR DESCRIPTION
This makes it a little more obvious that the "Twit-arr" menu is clickable.