### PR TITLE
Fix websockets over ssl

### DIFF
--- a/Sources/App/Resources/Assets/js/swiftarrMessages.js
+++ b/Sources/App/Resources/Assets/js/swiftarrMessages.js
@@ -1,7 +1,11 @@
 function startLiveMessageStream() {
 	let endDiv = document.getElementById("fez-list-end")
 	let socketURL = endDiv.dataset.url
-	ws = new WebSocket("ws://" + window.location.host + socketURL)
+	let wsProtocol = "ws://"
+	if (window.location.href.startsWith("https")) {
+		wsProtocol = "wss://"
+	}
+	ws = new WebSocket(wsProtocol + window.location.host + socketURL)
  
 	ws.onopen = () => {
 		// Maybe show something here to indicate we're live updating?


### PR DESCRIPTION
This fixes #55 where websockets fail to connect over SSL because the protocol was hard-coded to be `ws://` which is not supported over HTTPS (`wss://`).