### PR TITLE
Add documentation for LOG_LEVEL config

### DIFF
--- a/Sources/Run/Private Swiftarr Config/Docker-Template.env
+++ b/Sources/Run/Private Swiftarr Config/Docker-Template.env
@@ -84,6 +84,11 @@ hostname=0.0.0.0
 #                       These images are referenced by filename in the db.
 #                       Examples: "~/swiftarr/Images", "/app/images"
 SWIFTARR_USER_IMAGES=/app/images
+#
+# LOG_LEVEL: Runtime log level. Standard values from https://github.com/apple/swift-log#log-levels
+#            are accepted.
+#            Examples: "debug", "notice", "info"
+LOG_LEVEL=info
 
 # Server Passwords
 #

--- a/Sources/Run/Private Swiftarr Config/Template.env
+++ b/Sources/Run/Private Swiftarr Config/Template.env
@@ -26,6 +26,7 @@ REDIS_PASSWORD=
 # HTTP Server Setup
 PORT=8081
 hostname=
+LOG_LEVEL=info
 
 # Server Passwords
 ADMIN_PASSWORD=


### PR DESCRIPTION
IIRC `info` was the default for development. Production defaulted to `notice`.