### PR TITLE
Add support for Swift-Format

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,8 @@
+{
+  "indentation" : {
+    "tabs" : 1
+  },
+  "lineLength" : 120,
+  "tabWidth" : 4,
+  "version" : 1
+}


### PR DESCRIPTION
This enables the use of Apple's [swift-format](https://github.com/apple/swift-format) utility to ensure something resembling a common code style. Defaults are used with the exception of the options specified in this file. We already talked about some code formatting preferences in private so this shouldn't represent anything too odd.

I assume this thing works nearly out-of-the-box on Mac/Xcode. Linux/VSCode was relatively easy to set up after getting the right version to match my Swift version (currently 5.5.2, not 5.6 yet).